### PR TITLE
In RESTEASY-2985 we attempt to not reconnect if a 204 is sent via a S…

### DIFF
--- a/resteasy-tck-adapter/pom.xml
+++ b/resteasy-tck-adapter/pom.xml
@@ -297,6 +297,7 @@
                     </dependenciesToScan>
                     <systemPropertyVariables>
                         <jboss.home>${jboss.home}</jboss.home>
+                        <dev.resteasy.sse.closed.response.code>200</dev.resteasy.sse.closed.response.code>
                         <cts.harness.debug>${tck.log.debug}</cts.harness.debug>
                         <junit.log.traceflag>${tck.log.debug}</junit.log.traceflag>
                         <servlet_adaptor>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet_adaptor>

--- a/resteasy-tck-adapter/src/test/resources/arquillian.xml
+++ b/resteasy-tck-adapter/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
     <container qualifier="default" default="true">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">${debugJvmArgs}</property>
+            <property name="javaVmArguments">-Ddev.resteasy.sse.closed.response.code=200 ${debugJvmArgs}</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
…seEventSink. However, the TCK has some expectation that a SseEventSink.close() will produce a 200 as that's what other implementations do. We simply added a way to override the default response code for these cases.

Required for https://github.com/resteasy/resteasy/pull/3827