### PR TITLE
Update the CI workflow for some better names and remove the matrix.os…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Pull Requests
+name: RESTEasy Jakarta REST 4.0 TCK
 
 on:
   push:
@@ -29,12 +29,11 @@ concurrency:
 jobs:
   build:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         java: ['17', '21']
 
     steps:
@@ -45,16 +44,16 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
-      - name: Build with Java ${{ matrix.java }} - ${{ matrix.os }}
+      - name: Jakarta REST 4.0 JDK-${{ matrix.java }}
         run:  |
           mvn -ntp clean install -U -B -fae
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}
+          name: surefire-reports-${{ matrix.java }}
           path: '**/failsafe-reports/'
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: server-logs-${{ matrix.os }}-${{ matrix.java }}
+          name: server-logs-${{ matrix.java }}
           path: '**/server.log'

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version.jakarta.ws.rs.tck>4.0.1</version.jakarta.ws.rs.tck>
 
         <!-- Plugin versions -->
-        <version.org.wildfly.plugin>5.0.1.Final</version.org.wildfly.plugin>
+        <version.org.wildfly.plugin>5.1.0.Beta2</version.org.wildfly.plugin>
 
         <maven.repo.local>${settings.localRepository}</maven.repo.local>
     </properties>


### PR DESCRIPTION
… as we only run on one OS. Upgrade the wildfly-maven-plugin to 5.1.0.Beta2 so it can provision WildFly 35.